### PR TITLE
Bump eventmachine to 1.0.4 to fix on osx

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
     cinch (2.1.0)
     colorize (0.7.3)
     daemons (1.1.9)
-    eventmachine (1.0.3)
+    eventmachine (1.0.4)
     little-plugger (1.1.3)
     logging (1.8.2)
       little-plugger (>= 1.1.3)


### PR DESCRIPTION
Eventmachine 1.0.3 doesn't build on some combinations of ruby and os x- https://github.com/eventmachine/eventmachine/issues/553
